### PR TITLE
Improve pagination functionality and update filter component to reset…

### DIFF
--- a/expensetrackerapi/Services/ExpenseService.cs
+++ b/expensetrackerapi/Services/ExpenseService.cs
@@ -102,7 +102,7 @@ namespace expensetrackerapi.Services
         }
 
         public async Task<Result<object>> GetTransactions(string? userId, int? month, int? year, int? bucket,
-            int pageNumber = 1, int pageSize = 3)
+            int pageNumber = 1, int pageSize = 10)
         {
             if (userId == null)
             {
@@ -197,10 +197,12 @@ namespace expensetrackerapi.Services
             {
                 var bucketYearTransactions = await _db.Transactions
                     .Where(t => t.ApplicationUserId == userId && t.CreatedAt.Year == year && t.BucketId == bucket)
-                    .OrderByDescending(t => t.CreatedAt)
-                    .Skip((pageNumber - 1) * pageSize)
-                    .Take(pageSize)
                     .ToListAsync();
+
+                var pagedBucketYearTransactions = bucketYearTransactions.OrderByDescending(t => t.CreatedAt)
+                    .Skip((pageNumber - 1) * pageSize)
+                    .Take(pageSize);
+
 
                 _logger.LogInformation(
                     "User:{UserId} received all transactions with parameters: Year: {Year}, BucketId: {BucketId} ",
@@ -209,8 +211,9 @@ namespace expensetrackerapi.Services
                 return Result<object>.Success(
                     new
                     {
-                        Total = bucketYearTransactions.Count,
-                        Transactions = bucketYearTransactions
+                        Total = bucketYearTransactions.Count(),
+                        PageTotal = pagedBucketYearTransactions.Count(),
+                        Transactions = pagedBucketYearTransactions
                     }
                 );
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ function App() {
   const [errorMessage, setErrorMessage] = useState<Error | undefined>();
   // buckets state
   const [buckets, setBuckets] = useState<Bucket[]>([]);
+
+    const [currentPage, setCurrentPage] = useState<number>(1)
   
   return (
       <BrowserRouter>
@@ -35,12 +37,14 @@ function App() {
                 <>
                   <Navbar/>
                     <BucketList setBuckets={setBuckets} buckets={buckets} transactions={transactions}/>
-                    <Filter buckets={buckets}/>
+                    <Filter buckets={buckets} setCurrentPage={setCurrentPage}/>
 
                   {/*  Pass here the buckets state*/}
                   <TransactionTable transactions={transactions} setTransactions={setTransactions}
                                     ErrorMessage={errorMessage} buckets={buckets} setBuckets={setBuckets}/>
-                  <Pagination setTransactions={setTransactions} setErrorMessage={setErrorMessage}/>
+
+                    <Pagination setTransactions={setTransactions} setErrorMessage={setErrorMessage}
+                                setCurrentPage={setCurrentPage} currentPage={currentPage}/>
                 </>
               }
           />

--- a/src/components/BucketOverviewTable.tsx
+++ b/src/components/BucketOverviewTable.tsx
@@ -1,5 +1,5 @@
 ﻿import {useEffect, useState} from "react";
-import type {TransactionsSummary} from "../components/OverviewRow"
+import type {TransactionsSummary} from "./OverviewRow.tsx"
 import OverviewRow from "./OverviewRow"
 import TotalCard from "./TotalCard"
 import {BucketType} from "../types/BucketType.tsx"
@@ -19,7 +19,6 @@ const BucketOverviewTable = () => {
         month: currentMonth.toString(),
         year: currentYear.toString()
     })
-
     const months: string[] = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
     
     const [errorMessage, setErrorMessage] = useState<Error | undefined>()

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,14 +1,15 @@
-import {useEffect, useState} from "react";
+import {type Dispatch, type SetStateAction, useEffect, useState} from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import "../styles/Filter.css";
 import type {Bucket} from "../types/Bucket.tsx";
 
 interface FilterProps {
     buckets: Bucket[]
+    setCurrentPage: Dispatch<SetStateAction<number>>
 }
 
 
-const Filter = ({buckets}: FilterProps) => {
+const Filter = ({buckets, setCurrentPage}: FilterProps) => {
     const [isShown, setisShown] = useState<boolean>(false);
     const [errorMessage, setErrorMessage] = useState<Error | undefined>();
     const [userBuckets, setUserBuckets] = useState<Bucket[]>([]);
@@ -49,6 +50,12 @@ const Filter = ({buckets}: FilterProps) => {
         fetchUserbuckets()
     }, [buckets])
 
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [activeId, setCurrentPage]);
+    
+    
+
     const ErrorMessageStyle = {
         color: "#B00020",
         backgroundColor: "#FFEBEE",
@@ -61,7 +68,8 @@ const Filter = ({buckets}: FilterProps) => {
         marginTop: "6px"
     };
 
-    const YEAR = new Date().getFullYear();
+    const CURRENT_YEAR = 2026
+    
     return (
         <div
             id="transaction-filter"
@@ -94,7 +102,7 @@ const Filter = ({buckets}: FilterProps) => {
                             id={bucket.bucket.name}
                             checked={activeId === bucket.bucket.id.toString()}
                             onChange={() => {
-                                navigate(`?id=${bucket.bucket.id}&year=${YEAR}`);
+                                navigate(`?id=${bucket.bucket.id}&year=${CURRENT_YEAR}`);
                                 setisShown(false);
                             }}
                         />

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import type { Transaction } from "../types/Transaction";
 import { useSearchParams } from "react-router-dom";
 import type { Dispatch, SetStateAction } from "react";
@@ -9,26 +9,27 @@ interface PaginationProps {
     // Type for useState setter function is Dispatch<SetStateAction>
     setTransactions: Dispatch<SetStateAction<Transaction[]>>
     setErrorMessage: Dispatch<SetStateAction<Error | undefined>>
+    setCurrentPage: Dispatch<SetStateAction<number>>
+    currentPage: number
 }
 
-const Pagination = ({ setTransactions, setErrorMessage }: PaginationProps) => {
-  const [page, SetPage] = useState(1);
-  const [total, setTotal] = useState<number>(1);
+const Pagination = ({setTransactions, setErrorMessage, setCurrentPage, currentPage}: PaginationProps) => {
+    const [total, setTotal] = useState<number>(1);
 
   const [search] = useSearchParams();
-
   const PAGESIZE = 10;
   const TOTALPAGES = total / PAGESIZE;
     const PageAmount: number = Math.ceil(TOTALPAGES);
-  
-  useEffect(() => {
+
+
+    useEffect(() => {
     const fetchTransactions = async () => {
       try {
           const month = search.get("month")
           const year = search.get("year") 
-          const bucketId = search.get("id") 
-          
-          let url = `https://localhost:7118/api/v1/transactions?pageNumber=${page}&pageSize=${PAGESIZE}`
+          const bucketId = search.get("id")
+
+          let url = `https://localhost:7118/api/v1/transactions?pageNumber=${currentPage}&pageSize=${PAGESIZE}`
           
           if(year !== null ){
               url = url + `&year=${year}`
@@ -77,34 +78,37 @@ const Pagination = ({ setTransactions, setErrorMessage }: PaginationProps) => {
       
     };
     fetchTransactions();
-  }, [page, search, setErrorMessage, setTransactions]); //! beide als dependancy
+    }, [currentPage, search, setErrorMessage, setTransactions, setTotal]); //! beide als dependancy
 
   return (
       <div>
           {
-              Math.ceil(TOTALPAGES) === 0 ? <p>No transactions found</p> :
+              Math.ceil(TOTALPAGES) === 0 ? <p>No transactions found</p> : 
                   <div>
 
                       <p>
-                          Page: {page}/{PageAmount}
+                          Showing {((currentPage - 1) * PAGESIZE) + 1}-{Math.min(currentPage * PAGESIZE, total)} of {total} transactions
                       </p>
+
+                      {/*// previous button*/}
                       <input
                           type="button"
                           value="Prev"
-                          disabled={page === 1}
+                          disabled={currentPage === 1}
                           onClick={() => {
-                              if (page > 0) {
-                                  SetPage(page - 1);
+                              if (currentPage > 0) {
+                                  setCurrentPage(currentPage - 1);
                               }
                           }}
                       />
+                      {/*// next button*/}
                       <input
                           type="button"
                           value="Next"
-                          disabled={page === PageAmount} // why does it work only with === (loose/strict equality in JS?)
+                          disabled={currentPage === PageAmount} // why does it work only with === (loose/strict equality in JS?)
                           onClick={() => {
-                              if (page <= TOTALPAGES) {
-                                  SetPage(page + 1);
+                              if (currentPage <= TOTALPAGES) {
+                                  setCurrentPage(currentPage + 1);
                               }
                           }}
                       />


### PR DESCRIPTION
- I refactored the service method of the GET endpoint to retrieve transactions filtered on a `year `and  `bucketId`, so it also returns the total amount of transactions and not only the amount of one page.
- Move the state for the `currentPage `of the `Pagination `component to `App `so it becomes shared state between the `Pagination `and `Filter `components. When a filter for a bucket is clicked it will now go back to 1 instead of the page that is selected on the begin screen (all transactions, for example page 3).
- Now because the  makes use of a state setter function on line 65 it now shows the correct amount of pages (2 pages for 15 items for example)